### PR TITLE
Add build/revision information to conf & Makefile

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -12,7 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -166,5 +166,9 @@ html_context = {
     'github_user': 'hyperledger-labs',
     'github_repo': 'perun-doc',
     'github_version': 'master/',
-    'conf_py_path': 'source/'
+    'conf_py_path': 'source/',
+
+    'build_id': os.getenv('CIRCLE_BUILD_NUM', ''),
+    'build_url': os.getenv('CIRCLE_BUILD_URL', ''),
+    'commit': os.getenv('GIT_COMMIT', '')[:7]
 }


### PR DESCRIPTION
sphinx_rtd_theme's footer template will add build or commit info if
available. Therefore change the configuration and Makefile so that
  - CircleCI's build info or
  - the git commit sha
can picked up and printed on the documentation's footer if available.
The CircleCI environment variables are available if the build is invoked
by CircleCI. The git commit sha will be passed by make to the sphinx
build if it is invoked from a clean git working tree.

The basic build functionality, e.g. the `make html` target still works,
even if invoked from a git archive, i.e. when there is no git
information accessible.
