### PR TITLE
Fix exluding branches in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,9 @@ workflows:
       - setup-linkcheck-build:
           filters:
             branches:
-              ignore: master,gh-pages
+              ignore:
+                - master
+                - gh-pages
 
   build-deploy-docs:
     jobs:


### PR DESCRIPTION
#36 implements only a partial fix (providing a circleci config in the gh-pages branch).

This PR fixes a bug of the circleci config introduced in #34.