### PR TITLE
Rename master branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - main
                 - gh-pages
 
   build-deploy-docs:
@@ -68,4 +68,4 @@ workflows:
       - setup-linkcheck-build-deploy:
           filters:
             branches:
-              only: master
+              only: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ project. For issues / pull requests related to source code please refer to the
        how to write a good **commit** message. If available, include the
        ticket number. And don't forget the [Signed-Off-By](#sign-your-work)
        line.
-    2. Create a pull request against the master branch.
+    2. Create a pull request against the main branch.
 
 ## Legal stuff
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2020, Perun Framework Contributors'
 author = u'Perun Framework Contributors'
 
 # The short X.Y version
-version = u'master'
+version = u'main'
 # The full version, including alpha/beta/rc tags
-release = u'master'
+release = u'main'
 
 
 # -- General configuration ---------------------------------------------------
@@ -168,7 +168,7 @@ html_context = {
     'github_host': 'github.com',
     'github_user': 'hyperledger-labs',
     'github_repo': 'perun-doc',
-    'github_version': 'master/',
+    'github_version': 'main/',
     'conf_py_path': 'source/',
 
     'build_id': os.getenv('CIRCLE_BUILD_NUM', ''),

--- a/source/node/introduction.rst
+++ b/source/node/introduction.rst
@@ -65,7 +65,7 @@ on the blockchain, settle it and withdraw the funds back to the user's account.
 
 Starting the perun-node will run a gRPC server for communication. Complete
 specification of the payment channel API served by the perun-node can be found
-[here](https://github.com/hyperledger-labs/perun-proposals/blob/master/design/001-RPC-Interface-Specification.md).
+[here](https://github.com/hyperledger-labs/perun-proposals/blob/main/design/001-RPC-Interface-Specification.md).
 
 Perun-node cli
 ==============


### PR DESCRIPTION
Fix some references to `master` after renaming
the `master` branch to `main`.
