### PR TITLE
Add Migration section

### DIFF
--- a/source/go-perun/app_tutorial/app/app_offchain.rst
+++ b/source/go-perun/app_tutorial/app/app_offchain.rst
@@ -13,7 +13,7 @@ The game state is handled in ``TicTacToeAppData``, which implements *go-perun*'s
 The ``Grid`` indices are defined from the upper left to the lower right.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/data.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/data.go#L17>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/data.go#L17>`__
     :language: go
     :lines: 12-20
 
@@ -25,7 +25,7 @@ It is needed to push the local game data to the smart contract.
 Decoding will take place in the :ref:`app implementation <app_decoding>`.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/data.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/data.go#L32>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/data.go#L32>`__
     :language: go
     :lines: 31-40
 
@@ -37,7 +37,7 @@ To get the grid field index from ``x`` and ``y``, we calculate :math:`i = y+3+x`
 Then we update ``TicTacToeAppData.NextActor`` with ``calcNextActor``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/data.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/data.go#L48>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/data.go#L48>`__
     :language: go
     :lines: 48-55
 
@@ -47,14 +47,14 @@ We implement a simple ``String`` method that prints the match field into the com
 This will be handy for following the game's progress later on.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/data.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/data.go#L22>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/data.go#L22>`__
     :language: go
     :lines: 22-29
 
 To allow copying ``TicTacToeAppData``, we provide ``Clone``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/data.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/data.go#L43>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/data.go#L43>`__
     :language: go
     :lines: 42-46
 
@@ -74,7 +74,7 @@ If one of the fields is not set or is set but with another value, we return ``fa
 If all fields match, we return ``true`` with the respective ``PlayerIndex``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/util.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/util.go#L99>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/util.go#L99>`__
     :language: go
     :lines: 99-114
 
@@ -86,7 +86,7 @@ With ``CheckFinal``, we take the current state of the match field and evaluate i
 We start by listing all winning possibilities in an array.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/util.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/util.go#L71>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/util.go#L71>`__
     :language: go
     :lines: 71-81
 
@@ -118,7 +118,7 @@ In our case, *the winner takes it all*. Therefore, we add the loser's balance to
 Ultimately we return the final balance ``finalBals``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/util.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/util.go#L162>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/util.go#L162>`__
     :language: go
     :lines: 162-170
 
@@ -140,7 +140,7 @@ Data structure
 The implement the off-chain component as type ``TicTacToeApp``, which holds an address that links the object to the respective smart contract.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L29>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L29>`__
     :language: go
     :lines: 28-37
 
@@ -151,14 +151,14 @@ Initialization
 We create a getter for the app's smart contract address ``Addr`` with ``Def``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L40>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L40>`__
     :language: go
     :lines: 39-42
 
 Further, we create ``InitData``, which wraps the ``TicTacToeAppData`` constructor to generate a new match field with a given party ``firstActor`` as the first to be allowed to make a move.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L44>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L44>`__
     :language: go
     :lines: 44-48
 
@@ -175,7 +175,7 @@ Then we fetch the grid values by calling ``readUInt8Array``, which reads the nex
 Finally, we convert the bytes to their respective field values by calling ``makeFieldValueArray``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L51>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L51>`__
     :language: go
     :lines: 50-66
 
@@ -192,7 +192,7 @@ If the given arguments do not match the expected ones for a valid app channel in
 #. **Actor index.** Validate the index of the ``NextActor``. If no deviations are found, ``nil`` is returned.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L69>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L69>`__
     :language: go
     :lines: 68-92
 
@@ -214,7 +214,7 @@ The method takes the channel's parameters ``channel.Params``, the old and (propo
 Check if the given ``Data`` included in the ``channel.State``'s is of the expected type.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L95>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L95>`__
     :language: go
     :lines: 94-109
 
@@ -262,6 +262,6 @@ Finally, we check if the move eventually lets the client win the game.
 We again use ``CheckFinal`` to compute the respective balances via ``computeFinalBalances`` in case a ``winner`` is found.
 
 .. literalinclude:: ../../../perun-examples/app-channel/app/app.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/app/app.go#L161>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/app/app.go#L161>`__
     :language: go
     :lines: 161-177

--- a/source/go-perun/app_tutorial/app/app_onchain.rst
+++ b/source/go-perun/app_tutorial/app/app_onchain.rst
@@ -10,7 +10,7 @@ Valid game moves and winning conditions are defined here.
     Any possible exploit in this method breaks the app channel's security guarantees and put's funds at risk.
 
 .. literalinclude:: ../../../perun-examples/app-channel/contracts/TicTacToeApp.sol
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/contracts/TicTacToeApp.sol#L17>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/contracts/TicTacToeApp.sol#L17>`__
     :language: none
     :lines: 17-28
 
@@ -32,7 +32,7 @@ We define ``validTransition`` to evaluate if a move is considered valid or not.
 ``Channel.State``'s ``from`` and ``to`` hold the game state as ``Channel.State.appData`` and ``Channel.State.isFinal``.
 
 .. literalinclude:: ../../../perun-examples/app-channel/contracts/TicTacToeApp.sol
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/contracts/TicTacToeApp.sol#L46>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/contracts/TicTacToeApp.sol#L46>`__
     :language: none
     :lines: 39-52
 
@@ -77,7 +77,7 @@ We simply iterate over these and check via ``sameValue`` if one symbol ticks all
 If this is the case, we return the respective winner and ``isFinal`` and ``hasWinner`` as true.
 
 .. literalinclude:: ../../../perun-examples/app-channel/contracts/TicTacToeApp.sol
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/contracts/TicTacToeApp.sol#L89>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/contracts/TicTacToeApp.sol#L89>`__
     :language: none
     :lines: 89-109
 
@@ -97,7 +97,7 @@ Finally we implement the two helper ``sameValue`` and ``requireEqualUint256Array
 If these indices refer to ticked grid fields by the same player, we return ``true`` and the player's id.
 
 .. literalinclude:: ../../../perun-examples/app-channel/contracts/TicTacToeApp.sol
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/contracts/TicTacToeApp.sol#L120>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/contracts/TicTacToeApp.sol#L120>`__
     :language: none
     :lines: 120-128
 
@@ -105,7 +105,7 @@ If these indices refer to ticked grid fields by the same player, we return ``tru
 We do not return anything here because a ``require`` is used to compare, therefore aborting the call if inequality is detected.
 
 .. literalinclude:: ../../../perun-examples/app-channel/contracts/TicTacToeApp.sol
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/contracts/TicTacToeApp.sol#L130>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/contracts/TicTacToeApp.sol#L130>`__
     :language: none
     :lines: 130-141
 

--- a/source/go-perun/app_tutorial/client.rst
+++ b/source/go-perun/app_tutorial/client.rst
@@ -17,7 +17,7 @@ The only additional parameters here are ``stake`` and ``app``.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/client.go
     :emphasize-lines: 6,7
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/client.go#L41>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/client.go#L41>`__
     :language: go
     :lines: 40-48
 
@@ -34,7 +34,7 @@ We realize this by putting ``stake`` for both ``channel.Bal`` indices when calli
 
 .. literalinclude:: ../../perun-examples/app-channel/client/client.go
     :emphasize-lines: 7-10
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/client.go#L117>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/client.go#L117>`__
     :language: go
     :lines: 116-125
 
@@ -64,7 +64,7 @@ Furthermore, we check that the funding agreement, ``lcp.FundingAgreement``, corr
 
 .. literalinclude:: ../../perun-examples/app-channel/client/handle.go
     :emphasize-lines: 10-12, 30,31
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/handle.go#L26>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/handle.go#L26>`__
     :language: go
     :lines: 25-61
 
@@ -80,7 +80,7 @@ We don't need to do much here in the app channel case for handling state updates
 We can accept every update because the app's :ref:`valid transition function <app_validate_transition>` ensures that the transition is valid.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/handle.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/handle.go#L81>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/handle.go#L81>`__
     :language: go
     :lines: 80-88
 
@@ -94,7 +94,7 @@ We implement the type ``TicTacToeChannel`` that wraps a Perun channel and provid
 We put this functionality in ``client/channel.go``.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/channel.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/channel.go#L13>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/channel.go#L13>`__
     :language: go
     :lines: 12-15
 
@@ -111,7 +111,7 @@ Then we call ``TicTacToeApp.Set``, which will manipulate ``state.Data`` to inclu
 We will go into more detail about this in the :ref:`app description <app_set>`.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/channel.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/channel.go#L23>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/channel.go#L23>`__
     :language: go
     :lines: 22-35
 
@@ -128,7 +128,7 @@ This forced update bypasses the state channel and registers a game move directly
     In this case, *A* utilizes ``ForceSet`` with its proposed update to enforce the game rules on-chain without full consensus and win the game properly.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/channel.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/channel.go#L38>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/channel.go#L38>`__
     :language: go
     :lines: 37-55
 
@@ -138,7 +138,7 @@ Settling the channel is quite similar to the way :ref:`we already implemented <p
 But in our case, we can skip the finalization part because we expect the app logic to finalize the channel after the winning move.
 
 .. literalinclude:: ../../perun-examples/app-channel/client/channel.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/client/channel.go#L58>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/client/channel.go#L58>`__
     :language: go
     :lines: 57-68
 

--- a/source/go-perun/app_tutorial/test.rst
+++ b/source/go-perun/app_tutorial/test.rst
@@ -45,7 +45,7 @@ We call ``deployContracts`` with the corresponding arguments to receive the ``ad
 Using ``appAddress`` we initialize a new ``TicTacToeApp``.
 
 .. literalinclude:: ../../perun-examples/app-channel/main.go
-    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/app-channel/main.go#L39>`__
+    :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/app-channel/main.go#L39>`__
     :language: go
     :lines: 36-44
 

--- a/source/go-perun/index.rst
+++ b/source/go-perun/index.rst
@@ -38,8 +38,11 @@ Architecture
 By default, the library ships with an Ethereum adapter as the transaction backend, a TCP/IP adapter for client communication, a LevelDB adapter for data persistence, and a Logrus adapter for logging.
 
 
-Payment Channel Tutorial
-------------------------
+Tutorials
+---------
+
+Payment Channels
+~~~~~~~~~~~~~~~~
 In the :ref:`payment channel tutorial <payment_tutorial_intro>`, you will learn how to build a simple payment channel application that uses Perun channels for realizing fast and low-fee payment transactions.
 
 .. toctree::
@@ -48,10 +51,9 @@ In the :ref:`payment channel tutorial <payment_tutorial_intro>`, you will learn 
    payment_tutorial/intro
    payment_tutorial/client
    payment_tutorial/test
-   payment_tutorial/dot
 
-App Channel Tutorial
---------------------
+App Channels
+~~~~~~~~~~~~
 In the :ref:`app channel tutorial <app_tutorial_intro>`, we guide you through the process of creating an app channel application where two players trustlessly play an interactive game with blockchain tokens at stake.
 
 .. toctree::
@@ -61,3 +63,12 @@ In the :ref:`app channel tutorial <app_tutorial_intro>`, we guide you through th
    app_tutorial/app/app_intro
    app_tutorial/client
    app_tutorial/test
+
+Blockchain Migration
+~~~~~~~~~~~~~~~~~~~~
+In :ref:`payment_client_on_polkadot`, you will learn how to migrate the payment channel client from Ethereum to Polkadot.
+
+.. toctree::
+   :maxdepth: 1
+
+   port_eth_dot/index

--- a/source/go-perun/index.rst
+++ b/source/go-perun/index.rst
@@ -66,9 +66,9 @@ In the :ref:`app channel tutorial <app_tutorial_intro>`, we guide you through th
 
 Blockchain Migration
 ~~~~~~~~~~~~~~~~~~~~
-In :ref:`payment_client_on_polkadot`, you will learn how to migrate the payment channel client from Ethereum to Polkadot.
+In the :ref:`migration tutorial<payment_client_on_polkadot>`, you will learn how to migrate the payment channel client from Ethereum to Polkadot.
 
 .. toctree::
    :maxdepth: 1
 
-   port_eth_dot/index
+   port_eth_dot/migration

--- a/source/go-perun/index.rst
+++ b/source/go-perun/index.rst
@@ -48,6 +48,7 @@ In the :ref:`payment channel tutorial <payment_tutorial_intro>`, you will learn 
    payment_tutorial/intro
    payment_tutorial/client
    payment_tutorial/test
+   payment_tutorial/dot
 
 App Channel Tutorial
 --------------------

--- a/source/go-perun/payment_tutorial/client.rst
+++ b/source/go-perun/payment_tutorial/client.rst
@@ -19,7 +19,7 @@ The main part of our payment channel client is placed in ``client/client.go``.
 Our client is of type ``PaymentClient`` and holds the fields described below.
 
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L41>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L41>`__
    :language: go
    :lines: 40-46
 
@@ -30,7 +30,7 @@ Our client is of type ``PaymentClient`` and holds the fields described below.
 We first create the constructor for our ``PaymentClient``, which takes a number of parameters as described below.
 
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L49>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L49>`__
    :language: go
    :lines: 48-57
 
@@ -127,7 +127,7 @@ We do not expect the receiver to put funds into the channel in our case.
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
    :language: go
    :lines: 108-109
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L109>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L109>`__
 
 **Channel participants.**
 The channel participants are defined as a list of wire addresses.
@@ -201,7 +201,7 @@ The client will receive incoming channel proposals via ``HandleProposal``.
 .. literalinclude:: ../../perun-examples/payment-channel/client/handle.go
    :language: go
    :lines: 27-28
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/handle.go#L28>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/handle.go#L28>`__
 
 **Check proposal.**
 Before a channel proposal is accepted, it is essential to its parameters.
@@ -235,7 +235,7 @@ We define ``AcceptedChannel`` for fetching channels that the channel proposal ha
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
    :language: go
    :lines: 156-159
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L157>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L157>`__
 
 
 .. _client_channel:
@@ -249,7 +249,7 @@ We put this functionality in ``client/channel.go``.
 .. literalinclude:: ../../perun-examples/payment-channel/client/channel.go
    :language: go
    :lines: 11-23
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/channel.go#L12>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/channel.go#L12>`__
 
 
 Send Payment
@@ -263,7 +263,7 @@ We use *go-perun*'s ``TransferBalance`` function to automatically subtract the g
 .. literalinclude:: ../../perun-examples/payment-channel/client/channel.go
    :language: go
    :lines: 25-39
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/channel.go#L26>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/channel.go#L26>`__
 
 .. note::
    Note that any update must maintain the overall sum of funds inside the channel. Otherwise, the update is blocked.
@@ -276,7 +276,7 @@ The method gets as input the current channel state, the proposed update, and a r
 .. literalinclude:: ../../perun-examples/payment-channel/client/handle.go
    :language: go
    :lines: 72-73
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/handle.go#L73>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/handle.go#L73>`__
 
 We first check if the proposed update satisfies our payment channel conditions, i.e., that it increases our balance.
 If this is not the case, we reject using ``r.Reject``.
@@ -303,7 +303,7 @@ We create a method ``Settle``, that first tries to finalize the channel off-chai
 .. literalinclude:: ../../perun-examples/payment-channel/client/channel.go
    :language: go
    :lines: 41-62
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/channel.go#L42>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/channel.go#L42>`__
 
 .. _client_utility:
 
@@ -322,14 +322,14 @@ To start the dispute watcher for a given channel ``ch``, we call ``ch.Watch``, w
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
    :language: go
    :lines: 146-154
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L147>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L147>`__
 
 In our case, the client will handle the on-chain events and print them to the standard output.
 
 .. literalinclude:: ../../perun-examples/payment-channel/client/handle.go
    :language: go
    :lines: 100-103
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/handle.go#L101>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/handle.go#L101>`__
 
 Client shutdown
 ...............
@@ -338,7 +338,7 @@ To allow the client to shut down in a managed way, we define ``Shutdown``, which
 .. literalinclude:: ../../perun-examples/payment-channel/client/client.go
    :language: go
    :lines: 161-164
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/client.go#L162>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/client.go#L162>`__
 
 
 Contract backend
@@ -352,7 +352,7 @@ Our constructor of the contract backend requires three parameters.
 .. literalinclude:: ../../perun-examples/payment-channel/client/util.go
    :language: go
    :lines: 28-34
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/util.go#L30>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/util.go#L30>`__
 
 Using the ``chainID``, we start by creating an ``EIP155Signer`` provided by go-ethereum.
 We can now create a ``channel.Transactor`` by calling ``swallet.NewTransactor`` with inputting the wallet and the signer.
@@ -380,4 +380,4 @@ To accommodate for this, we implement ``EthToWei`` and ``WeiToEth`` to convert b
 .. literalinclude:: ../../perun-examples/payment-channel/client/util.go
    :language: go
    :lines: 55-71
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/client/util.go#L57>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/client/util.go#L57>`__

--- a/source/go-perun/payment_tutorial/dot.rst
+++ b/source/go-perun/payment_tutorial/dot.rst
@@ -1,0 +1,193 @@
+.. _payment_client_on_polkadot:
+
+Polkadot
+========
+
+In order to make our channel implementation work on Polkadot we utilize the `perun-polkadot-backend <https://github.com/perun-network/perun-polkadot-backend>`_.
+Most changes are done in the ``PaymentClient`` & its setup.
+The actual ``PaymentChannel`` implementation stays the same.
+
+Most notably, we don't need to deploy smart contracts like the *Adjudicator* and *AssetHolder* anymore.
+All necessary contracts are provided by the `perun-polkadot-pallet <https://github.com/perun-network/perun-polkadot-pallet>`_ which is deployed on the `perun-polkadot-node <https://github.com/perun-network/perun-polkadot-node>`_ we are using as our local test chain.
+
+.. note::
+    *Pallets* are modules that act as building blocks for constructing unique blockchains.
+    Each pallet contains domain-specific logic.
+    The *Perun Polkadot Pallet* provides *go-perun* state channels for all Substrate compatible blockchains.
+
+Changes
+-------
+The following modifications take the `Ethereum implementation <https://github.com/perun-network/perun-examples/tree/master/payment-channel>`_ as a foundation.
+Have a look at the full implementation in the `perun-examples <https://github.com/perun-network/perun-examples/tree/master/payment-channel-dot>`_ repository .
+
+Client
+......
+
+**Utilities.**
+We make adjustments to ``client/util.go`` first.
+As we are on Polkadot now, we replace the conversion functions ``EthToWei``/``WeiToEth`` with ``DotToPlanck``/``PlanckToDot``.
+Also, we drop the ``CreateContractBackend`` function.
+
+**Constructor.**
+Then we take a look at ``SetupPaymentClient`` in ``client/client.go``.
+Replacing ``CreateContractBackend`` is ``dot.API``, which acts as our chain connection by giving the ``nodeURL`` and ``networkId``.
+Then, we use the generated ``api`` to create a new ``Pallet`` from which we derive a new ``Funder`` and ``Adjudicator``.
+
+.. code-block:: go
+
+    // SetupPaymentClient creates a new payment client.
+    func SetupPaymentClient(
+        bus wire.Bus, // bus is used of off-chain communication.
+        w *dotwallet.Wallet, // w is the wallet used for signing transactions.
+        acc wallet.Account, // acc is the address of the account to be used for signing transactions.
+        nodeURL string, // nodeURL is the URL of the blockchain node.
+        networkId dot.NetworkID, // networkId is the identifier of the blockchain.
+        queryDepth types.BlockNumber, // queryDepth is the number of blocks being evaluated when looking for events.
+    ) (*PaymentClient, error) {
+        // Connect to backend.
+        api, err := dot.NewAPI(nodeURL, networkId)
+        if err != nil {
+            panic(err)
+        }
+
+        // Create Perun pallet and generate funder + adjudicator from it.
+        perun := pallet.NewPallet(pallet.NewPerunPallet(api), api.Metadata())
+        funder := pallet.NewFunder(perun, acc, 3)
+        adj := pallet.NewAdjudicator(acc, perun, api, queryDepth )
+
+
+We set up the dispute ``watcher`` and create the ``perunClient`` to instantiate the full ``PaymentClient``.
+Notice that we use the Polkadot specific wallet ``dotwallet`` and asset ``dotchannel.Asset`` here.
+
+.. code-block:: go
+
+        // Setup dispute watcher.
+        watcher, err := local.NewWatcher(adj)
+        if err != nil {
+            return nil, fmt.Errorf("intializing watcher: %w", err)
+        }
+
+        // Setup Perun client.
+        waddr := dotwallet.AsAddr(acc.Address())
+        perunClient, err := client.New(waddr, bus, funder, adj, w, watcher)
+        if err != nil {
+            return nil, errors.WithMessage(err, "creating client")
+        }
+
+        // Create client and start request handler.
+        c := &PaymentClient{
+            perunClient: perunClient,
+            account:     waddr,
+            currency:    &dotchannel.Asset,
+            channels:    make(chan *PaymentChannel, 1),
+        }
+
+        go perunClient.Handle(c, c)
+        return c, nil
+    }
+
+Setup
+.....
+We make some changes in ``util.go``:
+
+**Simplifications.** The ``deployContracts`` function is omitted as no contract deployment will be necessary.
+Also, the ``balanceLogger`` is updated to work with Polkadot addresses.
+
+**Client setup.** ``setupPaymentClient`` is adapted to suit the new ``paymentClient`` constructor.
+Most notably, we initialize a new Polkadot wallet ``dotwallet`` using the ``privateKey`` and propagate all parameters to the ``PaymentClient``.
+
+Run
+---
+We slightly adapt the demo scenario in ``main.go``.
+
+**Environment.** The following constants describe the updated test environment.
+
+.. code-block:: none
+
+    const (
+        chainURL        = "ws://127.0.0.1:9944"
+        networkID       = 42
+        blockQueryDepth = 100
+
+        // Private keys.
+        keyAlice = "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"
+        keyBob   = "0x398f0c28f98885e046333d4a41c19cee4c37368a9832c6502f6cfd182e2aef89"
+    )
+
+**Main function.** There are only minor adjustments made to the scenario sequence:
+
+- The contract deployment is removed.
+- We use ``blockQueryDepth`` in the ``setupPaymentClient`` call.
+
+.. note::
+    On our `Polkadot node <https://github.com/perun-network/perun-polkadot-node>`_, Alice and Bob both start with *1.153 MDot*. Hence we use a higher balance for funding and payments in ``main.go``.
+
+.. code-block:: go
+
+    // main runs a demo of the payment client. It assumes that a blockchain node is
+    // available at `chainURL` and that the accounts corresponding to the specified
+    // secret keys are provided with sufficient funds.
+    func main() {
+        // Setup clients.
+        log.Println("Setting up clients.")
+        bus := wire.NewLocalBus() // Message bus used for off-chain communication.
+        alice := setupPaymentClient(bus, chainURL, networkID, blockQueryDepth, keyAlice)
+        bob := setupPaymentClient(bus, chainURL, networkID, blockQueryDepth, keyBob)
+
+        // Print balances before transactions.
+        l := newBalanceLogger(chainURL, networkID)
+        l.LogBalances(alice.WalletAddress(), bob.WalletAddress())
+
+        // Open channel, transact, close.
+        log.Println("Opening channel and depositing funds.")
+        chAlice := alice.OpenChannel(bob.WireAddress(), 100000)
+        chBob := bob.AcceptedChannel()
+
+        log.Println("Sending payments...")
+        chAlice.SendPayment(50000)
+        chBob.SendPayment(25000)
+        chAlice.SendPayment(25000)
+
+        log.Println("Settling channel.")
+        chAlice.Settle() // Conclude and withdraw.
+        chBob.Settle()   // Withdraw.
+
+        // Print balances after transactions.
+        l.LogBalances(alice.WalletAddress(), bob.WalletAddress())
+
+        // Cleanup.
+        alice.Shutdown()
+        bob.Shutdown()
+    }
+
+Run from the command line
+.........................
+To run the example from the command line, start the local blockchain by calling the `perun-polkadot-node <https://github.com/perun-network/perun-polkadot-node>`_.
+Make sure the port ``-p`` matches with the one of the ``chainURL`` in the environment constants.
+
+.. code-block:: bash
+
+    docker run --rm -it -p 9944:9944 ghcr.io/perun-network/polkadot-test-node
+
+In a second terminal, run the demo:
+
+.. code-block:: bash
+
+    cd payment-channel-dot/
+    go run .
+
+If everything works, you should see the following output.
+
+.. code-block:: none
+
+    2022/04/11 15:04:52 Setting up clients.
+    2022/04/11 15:04:52 Connecting to ws://127.0.0.1:9944...
+    2022/04/11 15:04:52 Connecting to ws://127.0.0.1:9944...
+    2022/04/11 15:04:52 Connecting to ws://127.0.0.1:9944...
+    2022/04/11 15:04:52 Client balances (DOT): [1.153 MDot 1.153 MDot]
+    2022/04/11 15:04:52 Opening channel and depositing funds.
+    2022/04/11 15:04:54 Sending payments...
+    2022/04/11 15:04:54 Settling channel.
+    2022/04/11 15:04:54 Adjudicator event: type = *channel.ConcludedEvent, client = 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48
+    2022/04/11 15:04:59 Adjudicator event: type = *channel.ConcludedEvent, client = 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+    2022/04/11 15:05:05 Client balances (DOT): [1.103 MDot 1.203 MDot]

--- a/source/go-perun/payment_tutorial/intro.rst
+++ b/source/go-perun/payment_tutorial/intro.rst
@@ -59,13 +59,3 @@ Please make sure that it is installed. You can find installation instructions on
 
    # Check that ganache-cli is installed.
    ganache-cli --version
-
-Docker
-~~~~~~
-For the Polkadot part of the tutorial, we require *docker* to run our local `perun-polkadot-node <https://github.com/perun-network/perun-polkadot-node>`_.
-You can find installation instructions `here <https://docs.docker.com/engine/install/>`_.
-
-.. code-block:: bash
-
-   # Check that docker is installed.
-   docker -v

--- a/source/go-perun/payment_tutorial/intro.rst
+++ b/source/go-perun/payment_tutorial/intro.rst
@@ -4,7 +4,8 @@ Introduction
 =======================
 
 In this tutorial, we want to take a look at the process of creating a simple application that allows two clients, Alice and Bob, to open a *go-perun* channel and use it for performing off-chain payment transactions.
-We will use Ethereum as the blockchain backend for funding channels and resolving disputes.
+We start by using Ethereum as the blockchain backend for funding channels and resolving disputes.
+
 
 .. image:: ../../images/go-perun/alice_bob_ethereum.png
    :align: center
@@ -13,6 +14,7 @@ We will use Ethereum as the blockchain backend for funding channels and resolvin
 
 We will introduce the functionality that *go-perun* offers for this simple use case.
 The presented implementation can be used as an example that helps you build your own channel application.
+We also demonstrate the exchangeability of the underlying blockchain by switching our Ethereum payment channel :ref:`onto Polkadot <payment_client_on_polkadot>`.
 
 .. _payment_tutorial_deps:
 
@@ -57,3 +59,13 @@ Please make sure that it is installed. You can find installation instructions on
 
    # Check that ganache-cli is installed.
    ganache-cli --version
+
+Docker
+~~~~~~
+For the Polkadot part of the tutorial, we require *docker* to run our local `perun-polkadot-node <https://github.com/perun-network/perun-polkadot-node>`_.
+You can find installation instructions `here <https://docs.docker.com/engine/install/>`_.
+
+.. code-block:: bash
+
+   # Check that docker is installed.
+   docker -v

--- a/source/go-perun/payment_tutorial/intro.rst
+++ b/source/go-perun/payment_tutorial/intro.rst
@@ -4,8 +4,7 @@ Introduction
 =======================
 
 In this tutorial, we want to take a look at the process of creating a simple application that allows two clients, Alice and Bob, to open a *go-perun* channel and use it for performing off-chain payment transactions.
-We start by using Ethereum as the blockchain backend for funding channels and resolving disputes.
-
+We use Ethereum as the blockchain backend for funding channels and resolving disputes.
 
 .. image:: ../../images/go-perun/alice_bob_ethereum.png
    :align: center
@@ -14,7 +13,6 @@ We start by using Ethereum as the blockchain backend for funding channels and re
 
 We will introduce the functionality that *go-perun* offers for this simple use case.
 The presented implementation can be used as an example that helps you build your own channel application.
-We also demonstrate the exchangeability of the underlying blockchain by switching our Ethereum payment channel :ref:`onto Polkadot <payment_client_on_polkadot>`.
 
 .. _payment_tutorial_deps:
 

--- a/source/go-perun/payment_tutorial/test.rst
+++ b/source/go-perun/payment_tutorial/test.rst
@@ -197,4 +197,4 @@ If everything works, you should see the following output.
     2022/02/07 16:42:45 Client balances (ETH): [7 13]
 
 
-With this, we conclude our payment channel tutorial.
+With this, we conclude the Ethereum part of the payment channel tutorial.

--- a/source/go-perun/payment_tutorial/test.rst
+++ b/source/go-perun/payment_tutorial/test.rst
@@ -41,7 +41,7 @@ We then create a contract backend that will be used for deployment and define th
 .. literalinclude:: ../../perun-examples/payment-channel/util.go
    :language: go
    :lines: 33-44
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/util.go#L34>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/util.go#L34>`__
 
 Using the contract backend ``cb``, we then deploy the ``Adjudicator`` and the ``AssetHolderETH`` via *go-perun*'s ``DeployAdjudicator`` and ``DeployETHAssetholder``.
 Note that the Adjudicator must be deployed first because the asset holder depends on it.
@@ -62,7 +62,7 @@ The wallet is then used with the other required arguments to call ``SetupPayment
 .. literalinclude:: ../../perun-examples/payment-channel/util.go
    :language: go
    :lines: 61-92
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/util.go#L62>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/util.go#L62>`__
 
 Logging Balances
 ................
@@ -72,7 +72,7 @@ For this, we create a new type ``balanceLogger``, which simply wraps an ``ethcli
 .. literalinclude:: ../../perun-examples/payment-channel/util.go
    :language: go
    :lines: 94-106
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/util.go#L95>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/util.go#L95>`__
 
 We implement the logging of balances with ``LogBalances`` that takes a sequence of account addresses as input.
 For each address, the balance is fetched via go-ethereum's ``BalanceAt``.
@@ -80,7 +80,7 @@ For each address, the balance is fetched via go-ethereum's ``BalanceAt``.
 .. literalinclude:: ../../perun-examples/payment-channel/util.go
    :language: go
    :lines: 108-119
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/util.go#L109>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/util.go#L109>`__
 
 Run
 ---
@@ -121,7 +121,7 @@ The ``main`` function implements the following steps.
 .. literalinclude:: ../../perun-examples/payment-channel/main.go
    :language: go
    :lines: 33-73
-   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/689b8cdfef8ef8fb527723d52e6ce36dfe1b661c/payment-channel/main.go#L37>`__
+   :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel/main.go#L37>`__
 
 .. _run_the_app:
 

--- a/source/go-perun/payment_tutorial/test.rst
+++ b/source/go-perun/payment_tutorial/test.rst
@@ -198,3 +198,4 @@ If everything works, you should see the following output.
 
 
 With this, we conclude the Ethereum part of the payment channel tutorial.
+Further, a description on how to migrate this implementation onto Polkadot is available :ref:`here <payment_client_on_polkadot>`.

--- a/source/go-perun/port_eth_dot/index.rst
+++ b/source/go-perun/port_eth_dot/index.rst
@@ -1,7 +1,7 @@
 .. _payment_client_on_polkadot:
 
-Polkadot
-========
+Migrating from Ethereum to Polkadot
+===================================
 
 In order to make our channel implementation work on Polkadot we utilize the `perun-polkadot-backend <https://github.com/perun-network/perun-polkadot-backend>`_.
 Most changes are done in the ``PaymentClient`` & its setup.
@@ -14,6 +14,30 @@ All necessary contracts are provided by the `perun-polkadot-pallet <https://gith
     *Pallets* are modules that act as building blocks for constructing unique blockchains.
     Each pallet contains domain-specific logic.
     The *Perun Polkadot Pallet* provides *go-perun* state channels for all Substrate compatible blockchains.
+
+
+Dependencies
+------------
+
+Source Code
+...........
+
+*TODO: Insert link*
+
+Docker
+......
+For the Polkadot part of the tutorial, we require *docker* to run our local `perun-polkadot-node <https://github.com/perun-network/perun-polkadot-node>`_.
+You can find installation instructions `here <https://docs.docker.com/engine/install/>`_.
+
+.. code-block:: bash
+
+   # Check that docker is installed.
+   docker -v
+
+Reference to other dependencies
+...............................
+
+*TODO: Insert or reference other dependencies.*
 
 Changes
 -------

--- a/source/go-perun/port_eth_dot/migration.rst
+++ b/source/go-perun/port_eth_dot/migration.rst
@@ -3,7 +3,7 @@
 Migrating from Ethereum to Polkadot
 ===================================
 
-In order to make our channel implementation work on Polkadot we utilize the `perun-polkadot-backend <https://github.com/perun-network/perun-polkadot-backend>`_.
+In order to make our :ref:`payment channel implementation <payment_tutorial_intro>` work on Polkadot we utilize the `perun-polkadot-backend <https://github.com/perun-network/perun-polkadot-backend>`_.
 Most changes are done in the ``PaymentClient`` & its setup.
 The actual ``PaymentChannel`` implementation stays the same.
 
@@ -18,11 +18,17 @@ All necessary contracts are provided by the `perun-polkadot-pallet <https://gith
 
 Dependencies
 ------------
+Again, we require *Go* as described in the :ref:`payment channel dependencies <payment_tutorial_deps>`.
 
 Source Code
 ...........
+This tutorial's source code is available at `perun-examples/payment-channel-dot <https://github.com/perun-network/perun-examples/tree/master/payment-channel-dot>`_.
 
-*TODO: Insert link*
+.. code-block:: bash
+
+   # Download repository.
+   git clone https://github.com/perun-network/perun-examples.git
+   cd perun-examples/payment-channel-dot
 
 Docker
 ......
@@ -34,15 +40,9 @@ You can find installation instructions `here <https://docs.docker.com/engine/ins
    # Check that docker is installed.
    docker -v
 
-Reference to other dependencies
-...............................
-
-*TODO: Insert or reference other dependencies.*
-
 Changes
 -------
-The following modifications take the `Ethereum implementation <https://github.com/perun-network/perun-examples/tree/master/payment-channel>`_ as a foundation.
-Have a look at the full implementation in the `perun-examples <https://github.com/perun-network/perun-examples/tree/master/payment-channel-dot>`_ repository .
+The following modifications take the `Ethereum payment channel <https://github.com/perun-network/perun-examples/tree/master/payment-channel>`_ implementation as a foundation.
 
 Client
 ......
@@ -55,7 +55,7 @@ Also, we drop the ``CreateContractBackend`` function.
 **Constructor.**
 Then we take a look at ``SetupPaymentClient`` in ``client/client.go``.
 Replacing ``CreateContractBackend`` is ``dot.API``, which acts as our chain connection by giving the ``nodeURL`` and ``networkId``.
-Then, we use the generated ``api`` to create a new ``Pallet`` from which we derive a new ``Funder`` and ``Adjudicator``.
+Then, we use the generated ``api`` to connect to our ``Pallet`` from which we bootstrap a new ``Funder`` and ``Adjudicator``.
 
 .. code-block:: go
 
@@ -114,7 +114,7 @@ Setup
 .....
 We make some changes in ``util.go``:
 
-**Simplifications.** The ``deployContracts`` function is omitted as no contract deployment will be necessary.
+**General.** The ``deployContracts`` function is omitted as no contract deployment will be necessary.
 Also, the ``balanceLogger`` is updated to work with Polkadot addresses.
 
 **Client setup.** ``setupPaymentClient`` is adapted to suit the new ``paymentClient`` constructor.
@@ -144,7 +144,7 @@ We slightly adapt the demo scenario in ``main.go``.
 - We use ``blockQueryDepth`` in the ``setupPaymentClient`` call.
 
 .. note::
-    On our `Polkadot node <https://github.com/perun-network/perun-polkadot-node>`_, Alice and Bob both start with *1.153 MDot*. Hence we use a higher balance for funding and payments in ``main.go``.
+    On our `Polkadot node <https://github.com/perun-network/perun-polkadot-node>`_, Alice and Bob start with *1.153 MDot* each. Hence we use a higher balance for funding and payments in ``main.go``.
 
 .. code-block:: go
 
@@ -215,3 +215,5 @@ If everything works, you should see the following output.
     2022/04/11 15:04:54 Adjudicator event: type = *channel.ConcludedEvent, client = 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48
     2022/04/11 15:04:59 Adjudicator event: type = *channel.ConcludedEvent, client = 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
     2022/04/11 15:05:05 Client balances (DOT): [1.103 MDot 1.203 MDot]
+
+With this, we conclude the migration tutorial.

--- a/source/go-perun/port_eth_dot/migration.rst
+++ b/source/go-perun/port_eth_dot/migration.rst
@@ -4,7 +4,7 @@ Migrating from Ethereum to Polkadot
 ===================================
 
 In order to make our :ref:`payment channel implementation <payment_tutorial_intro>` work on Polkadot we utilize the `perun-polkadot-backend <https://github.com/perun-network/perun-polkadot-backend>`_.
-Most changes are done in the ``PaymentClient`` & its setup.
+Most changes are done in the ``PaymentClient`` and its setup.
 The actual ``PaymentChannel`` implementation stays the same.
 
 Most notably, we don't need to deploy smart contracts like the *Adjudicator* and *AssetHolder* anymore.
@@ -54,8 +54,8 @@ Also, we drop the ``CreateContractBackend`` function.
 
 **Constructor.**
 Then we take a look at ``SetupPaymentClient`` in ``client/client.go``.
-Replacing ``CreateContractBackend`` is ``dot.API``, which acts as our chain connection by giving the ``nodeURL`` and ``networkId``.
-Then, we use the generated ``api`` to connect to our ``Pallet`` from which we bootstrap a new ``Funder`` and ``Adjudicator``.
+We replace ``CreateContractBackend`` with ``dot.NewAPI``, which acts as our chain connection given the ``nodeURL`` and ``networkId``.
+Then, we use the resulting ``api`` object to create a ``Pallet`` from which we derive a new ``Funder`` and ``Adjudicator``.
 
 .. literalinclude:: ../../perun-examples/payment-channel-dot/client/client.go
     :caption: `👇 This code on GitHub. <https://github.com/perun-network/perun-examples/blob/4a225436710bb47d805dbc7652beaf27df74941f/payment-channel-dot/client/client.go#L45>`__
@@ -63,7 +63,7 @@ Then, we use the generated ``api`` to connect to our ``Pallet`` from which we bo
     :lines: 44-62
 
 We set up the dispute ``watcher`` and create the ``perunClient`` to instantiate the full ``PaymentClient``.
-Notice that we use the Polkadot specific wallet ``dotwallet`` and asset ``dotchannel.Asset`` here.
+Notice that we use the Polkadot specific wallet ``dotwallet.Wallet`` and asset ``dotchannel.Asset`` here.
 
 .. literalinclude:: ../../perun-examples/payment-channel-dot/client/client.go
     :language: go
@@ -71,13 +71,13 @@ Notice that we use the Polkadot specific wallet ``dotwallet`` and asset ``dotcha
 
 Setup
 .....
-We make some changes in ``util.go``:
+We apply the following changes to ``util.go``.
 
-**General.** The ``deployContracts`` function is omitted as no contract deployment will be necessary.
+**General.** The ``deployContracts`` function is omitted as the Perun Pallet is predeployed at node startup and therefore no contract deployment will be necessary.
 Also, the ``balanceLogger`` is updated to work with Polkadot addresses.
 
-**Client setup.** ``setupPaymentClient`` is adapted to suit the new ``paymentClient`` constructor.
-Most notably, we initialize a new Polkadot wallet ``dotwallet`` using the ``privateKey`` and propagate all parameters to the ``PaymentClient``.
+**Client setup.** The function ``setupPaymentClient`` is adapted to suit the new ``paymentClient`` constructor.
+Most notably, we create a Polkadot-specific wallet via ``dotwallet.NewWallet`` and adapt the constructor's parameters.
 
 Run
 ---
@@ -93,7 +93,7 @@ We slightly adapt the demo scenario in ``main.go``.
 **Main function.** There are only minor adjustments made to the scenario sequence:
 
 - The contract deployment is removed.
-- We use ``blockQueryDepth`` in the ``setupPaymentClient`` call.
+- We use ``blockQueryDepth`` in the ``setupPaymentClient`` call. This constant specifies how many blocks an event subscription scans for past events.
 
 .. note::
     On our `Polkadot node <https://github.com/perun-network/perun-polkadot-node>`_, Alice and Bob start with *1.153 MDot* each. Hence we use a higher balance for funding and payments in ``main.go``.

--- a/source/scripts/gen_github_links.py
+++ b/source/scripts/gen_github_links.py
@@ -97,7 +97,7 @@ def manipulate_rst_file(path):
                 rst_data.insert(index, caption)
                 print("Added caption to line " + str(index + 1) + " ...")
                 added_line_offset += 1
-            else:
+            elif caption_found and not overwrite_captions:
                 print("Skipped line " + str(index + 1) + " (do not overwrite) ...")
         else:
             print("Skipped line " + str(index + 1) + " (no keyword or line numbers found here) ...")


### PR DESCRIPTION
This section describes the process of replacing the payment channel Ethereum backend with Polkadot. 

ToDo: Change `code-block` to `literalinclude` once https://github.com/perun-network/perun-examples/pull/10 merged.