### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,9 +5,14 @@
 | Name              | GitHub    | [Discord][_chat_url] |
 |-------------------|-----------|----------------------|
 | Chris Hoeppler    | [choeppler](https://github.com/choeppler)         | choeppler#8002    |
-| Daniel Kunz       | [danielksan81](https://github.com/danielksan81)   | danielksan81#1327 |
 | Manoranjith       | [manoranjith](https://github.com/manoranjith)     | manoranjith#8124  |
 | Matthias Geihs    | [matthiasgeihs](https://github.com/matthiasgeihs) | mpn#9737          |
-| &nbsp;            |                                                   |                   |
+
+### Emeritus Maintainers
+
+| Name              | GitHub    | [Discord][_chat_url] |
+|-------------------|-----------|----------------------|
+| Daniel Kunz       | [danielksan81](https://github.com/danielksan81)   | danielksan81#1327 |
+
 
 [_chat_url]: https://discord.com/channels/905194001349627914/955484679635632148


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>